### PR TITLE
feat: add fact-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See each skill's `SKILL.md` for trigger phrases, inputs, and dependencies.
 | [gemini-carousel](skills/gemini-carousel/) | Slide-by-slide carousel generator with an approval gate. |
 | [quote-post](skills/quote-post/) | Claude writes the quote, Gemini recreates the image with the quote baked in. |
 | [analytics-dashboard](skills/analytics-dashboard/) | LinkedIn Analytics export to interactive React dashboard plus 5 data-backed recommendations. |
+| [fact-checker](skills/fact-checker/) | Verify every claim in a draft against primary sources before it publishes. Per-claim verdicts, voice-matching rewrites, no API keys. |
 <!-- SKILLS:END -->
 
 ## Installation
@@ -161,6 +162,9 @@ Once installed, ask Claude to help with content tasks and it will pick the right
 
 ### Analytics
 - `analytics-dashboard` — LinkedIn export to dashboard + 5 recommendations
+
+### Quality gate
+- `fact-checker` — per-claim primary-source verification before anything publishes
 
 ## Prerequisites
 

--- a/skills/fact-checker/SKILL.md
+++ b/skills/fact-checker/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: fact-checker
+description: >
+  Verify every claim in a drafted post against primary sources before it publishes. Extracts the numbers, quotes, prices, dates and capability claims, traces each one to its original source with live web search, then returns a per-claim verdict of verified, soften or cut. Use this skill whenever the user says "fact check this", "verify my claims", "check my facts", "are these numbers right", "is this accurate", or pastes a draft and asks whether the claims in it are true. Needs no API keys. Runs before post-formatter or reels-scripting output ships.
+---
+
+# Fact Checker
+
+## CRITICAL: Auto-start on load
+
+When this skill triggers, go straight to Step 1. Do not summarise. Do not explain why accuracy matters. Start immediately.
+
+## Step 1. Get the draft
+
+If the user pasted a draft in the same message (post, hook, reel script, carousel copy or newsletter section), use it and skip to Step 2.
+
+Otherwise ask:
+
+> Paste the draft you want fact checked.
+
+Wait for the draft.
+
+## Step 2. Extract every checkable claim
+
+List each statement a reader could prove wrong. Hunt for:
+
+- **Numbers**: statistics, percentages, prices, valuations, benchmark scores, user counts, revenue figures
+- **Quotes**: anything in quotation marks attributed to a person or company
+- **Dates**: launch dates, deadlines, "last week", "just announced"
+- **Capability claims**: "X can now do Y", "X beats Y", "the first tool that..."
+- **Availability**: is the thing usable today, or only announced
+- **Superlatives**: "biggest", "fastest", "first". Each one is a checkable claim.
+
+Number the claims. If the draft contains none, output `VERDICT: ACCURACY_PASS (no checkable claims)` and stop.
+
+Sanity gate before searching: check any arithmetic the draft implies. Percentages that should sum to 100, growth that implies impossible baselines, totals that do not match their parts. Arithmetic fails faster than search.
+
+## Step 3. Trace each claim to a primary source
+
+For each claim, search the live web and open the actual origin:
+
+- The company or lab's own blog post, changelog, pricing page or filing
+- The actual tweet, repo, paper or video, not a screenshot of one
+- For quotes: the interview, transcript or post where the words were said
+
+A roundup, a newsletter or another creator's post is not a source. It is a lead. Follow it to the origin.
+
+Two escalation rules:
+
+1. **Primary blocked.** Some origin sites refuse automated fetches. Corroborate the specific fact across other reachable official pages (a co-maker, a press page, a store listing) plus at least three independent reputable outlets, and note that the primary was unreachable.
+2. **Sources disagree.** If two sources give different figures, cite the range with attribution or cut the claim. Never pick the most dramatic number.
+
+The full source hierarchy and failure-mode catalogue live in [references/verification-playbook.md](references/verification-playbook.md). Read it when a claim is hard to classify.
+
+## Step 4. Assign a verdict to each claim
+
+Read voice.md and about-me.md from the project root if they exist, so every rewrite keeps the user's voice. If they are missing, note it and match the draft's own register.
+
+Three verdicts:
+
+- **VERIFIED**: the primary source confirms it. Attach the URL.
+- **SOFTEN**: directionally true but overstated. Supply a rewrite that downgrades the claim to what the source supports. The standard downgrades: "in my testing", "reportedly", "self-reported", "announced, not yet available".
+- **CUT**: no source found, a source directly contradicts it, rumour, or the numbers do not add up. Supply the sentence with the claim removed, or a sourced replacement claim.
+
+## Step 5. Output the report
+
+```
+FACT CHECK: [first line of the draft]
+
+| # | Claim | Verdict | Source or rewrite |
+|---|-------|---------|-------------------|
+| 1 | "..." | VERIFIED | https://... |
+| 2 | "..." | SOFTEN | suggested rewrite |
+| 3 | "..." | CUT | reason + replacement |
+
+VERDICT: [ACCURACY_PASS | N claims block publishing (see rows ...)]
+```
+
+The verdict line at report time: `ACCURACY_PASS` only when every row is VERIFIED. Every SOFTEN and CUT row counts as blocking until it is resolved in Step 6.
+
+## Step 6. Offer the fix
+
+Ask:
+
+> Want me to apply the rewrites and return the corrected draft?
+
+If yes, return the full corrected draft with every VERIFIED claim untouched and every SOFTEN or CUT row resolved, then re-issue the verdict line. A corrected draft earns `VERDICT: ACCURACY_PASS`.
+
+If no, the blocking verdict stands. Say so plainly:
+
+> The draft ships at your own risk. [N] claims did not survive verification.
+
+## Rules
+
+- Never fabricate or guess a number to fill a gap. A missing stat beats a wrong one.
+- "Probably true" is not verification. If you cannot point at the source, it is unverified.
+- Announced is not available. Check which one the draft claims.
+- Distrust vendor benchmarks and income claims by default. They are marketing until a primary source confirms them.
+- Never soften a claim its source fully supports. Confidence is earned by the check.
+- Rewrites must match voice.md. An accurate line in the wrong voice gets rejected anyway.
+- British English in reports. Rewrites follow voice.md, or the draft's own spelling when voice.md is missing.

--- a/skills/fact-checker/references/verification-playbook.md
+++ b/skills/fact-checker/references/verification-playbook.md
@@ -1,0 +1,60 @@
+# Verification playbook
+
+Reference for the fact-checker skill. Read when a claim is hard to classify.
+
+## Source hierarchy (strongest first)
+
+1. **The origin artefact.** The company or lab's own blog post, changelog, pricing page, model card, SEC filing or press release. The actual tweet or post, opened at its own URL. The repo. The paper.
+2. **Platform-official policy or documentation.** What the platform itself publishes about its own rules or features.
+3. **Large-sample studies with a published methodology.** An analytics vendor's study of millions of posts counts. Their marketing blog does not.
+4. **Independent reputable outlets, in numbers.** Only when the origin is unreachable, and only when at least three of them agree on the specific fact.
+5. **Everything else is a lead, not a source.** Roundups, newsletters, other creators' summaries and screenshots point you towards the origin. They never substitute for it.
+
+## Failure-mode catalogue
+
+The recurring ways confident posts turn out wrong. Check the draft against each.
+
+| Failure mode | What it looks like | The check |
+|---|---|---|
+| Announced as available | "You can now use X" when X is waitlist-only or demo-only | Find the access page. Try the signup path in the source. |
+| Mislabelled model or version | Benchmarks from one version attributed to another | Match the exact version string in the origin. |
+| Cherry-picked benchmark | "X beats Y" from one favourable metric | Read the full table. Report the range or the caveat. |
+| Rumour as fact | "X is acquiring Y" sourced to a single unsourced tweet | Origin or silence. No primary, no post. |
+| Roundup as source | A stat cited to a newsletter that cited a blog that cited nothing | Walk the chain to the end. If it dead-ends, cut. |
+| Self-reported as platform stat | One operator's income screenshot presented as a norm | Credit it as one person's claim or cut it. |
+| Spiciest-number selection | Three outlets say 3 different revenue figures, draft uses the biggest | Cite the range with attribution or cut. |
+| Arithmetic that fails | Percentages that sum past 100, growth that implies impossible baselines | Add the numbers up before searching anything. |
+| Stale claim | True at launch, false now (pricing, free tiers, limits change fast) | Check the date on the source. Re-verify anything older than the news cycle. |
+| Fabricated-looking precision | "$4,732 per month by day 90" style tables with no methodology | Demand the methodology. None found means cut. |
+
+## The blocked-primary protocol
+
+Origin sites often refuse automated fetches. When that happens:
+
+1. Do not drop down to a single roundup.
+2. Corroborate each individual fact across the maker's other reachable official pages (a co-maker, a press page, a store listing) plus at least three independent reputable outlets.
+3. Every fact must appear in multiple independent places. Outlets quoting the same wire story count once.
+4. Note in the report that the primary was unreachable and list what corroborated it.
+
+Treat this playbook's examples as illustrations only. Every verdict comes from a live search, never from a remembered or pattern-matched figure.
+
+## Worked example
+
+Draft claim: "NoteLoop's new plan costs $8 a month and already has 2 million users."
+
+1. Search for the maker's pricing page. It refuses automated fetch.
+2. The maker's press page (reachable) says $11 a month. Its launch post says "2 million registered accounts", which is not the same thing as users.
+3. Three independent outlets confirm $11 and quote the "registered accounts" figure with that exact wording.
+4. Verdict: CUT the price and replace with the sourced figure. SOFTEN the user claim to "2 million registered accounts, self-reported". The false precision would have been the top comment.
+
+## Softening vocabulary
+
+When a claim is directionally true but the source will not carry its full weight:
+
+- Capability you tried yourself: "in my testing"
+- Unconfirmed reporting: "reportedly", with the outlet named
+- Operator income or growth claims: "self-reported"
+- Launched on paper only: "announced, not yet available"
+- Disputed figures: "estimates range from X to Y", with attributions
+
+A softened claim keeps the story. A cut claim keeps the credibility. Both beat a confident error.


### PR DESCRIPTION
# PR title: `feat: add fact-checker`

## What changed

New skill `skills/fact-checker/` with `SKILL.md` and `references/verification-playbook.md`, plus one README table row and a new "Quality gate" category bullet.

## Features

- Extracts every checkable claim from a draft: numbers, quotes, prices, dates, capability claims, availability, superlatives
- Verifies each claim against primary sources with live web search. No API keys needed.
- Escalation protocols built in: blocked primary (corroborate across reachable official pages plus at least three independent outlets) and conflicting sources (cite the range or cut, never the most dramatic number)
- Per-claim verdicts: VERIFIED with source URL, SOFTEN with a voice-matching rewrite (reads voice.md and about-me.md like the other skills), CUT with a sourced replacement
- An ACCURACY_PASS gate with an apply-the-rewrites loop, so it slots in front of post-formatter or reels-scripting output
- The reference playbook carries the source hierarchy and a ten-row failure-mode catalogue: announced-as-available, roundup-as-source, self-reported-as-platform-stat, spiciest-number selection and friends

## Validation

- `./validate-skills.sh`: 93 passed, 0 warnings, 0 failures
- Added lines grepped for em/en dashes, semicolons, banned words and non-ASCII: clean
- `git diff --check`: clean
- End-to-end test: ran the skill against a draft about OpenAI's Codex Micro launch with five planted errors (wrong price, wrong key count, overstated capability, fabricated survey stat, false retail availability). It caught all five. openai.com refused the automated fetch, which exercised the blocked-primary protocol: every fact corroborated via worklouder.cc plus TechCrunch, 9to5Mac, Gizmodo and The New Stack.

Sample output from that run:

```
FACT CHECK: OpenAI just dropped its first hardware.

| # | Claim | Verdict | Source or rewrite |
|---|-------|---------|-------------------|
| 3 | "costs $199" | CUT | Wrong price. Every outlet says $230. Replacement: "The Codex Micro costs $230." |
| 5 | "Every key glows with your agent's live status" | SOFTEN | Only the six agent keys show live status. Rewrite: "Six agent keys glow with your agents' live status." |
| 6 | "93% of developers say..." | CUT | No such survey exists. The device launched today. |
| 7 | "grab one at any electronics store" | CUT | Direct from OpenAI only, limited run. |

VERDICT: 5 claims block publishing (see rows 3, 4, 5, 6, 7)
```

## Why

The set has writing, scoring and scripting skills but nothing that checks whether a draft's claims are true before they ship. Confident numbers are what comment sections attack first, and one debunked stat costs more credibility than ten great posts earn. This skill is extracted from the fact-checking gate in the content pipeline behind @tech_withtom and @build.withtom (AI news and AI builds pages on Instagram), where accuracy is the positioning.

Tom (@build.withtom)
