### PR TITLE
feat: add optional Atlas thumbnail generation

### DIFF
--- a/skills/youtube-thumbnail/SKILL.md
+++ b/skills/youtube-thumbnail/SKILL.md
@@ -80,9 +80,9 @@ Then ask:
 
 > Here's the brief. Say "generate" to output the image prompt or tell me what to change.
 
-## Step 4. Output the Gemini prompt
+## Step 4. Choose the image provider
 
-Once approved, output the image generation prompt in a code block:
+Gemini remains the default. Offer Atlas Cloud only when the user wants API-based generation. Once approved, output the image generation prompt in a code block:
 
 ```
 Using the attached reference photo of me, generate a YouTube thumbnail at 1280 x 720 pixels (16:9).
@@ -112,9 +112,20 @@ Constraints:
 - High contrast between face, text, and background
 ```
 
-Tell the user:
+For Gemini, tell the user:
 
 > Paste this into a new Gemini chat, attach your reference photo, enable Create Image, and select Nano Banana. Generate at 1280x720.
+
+For Atlas Cloud, check `ATLASCLOUD_API_KEY`, write the approved prompt to `thumbnail-prompt.txt` in the project root, then run from this skill directory:
+
+```bash
+python scripts/generate_atlas.py \
+  --reference /path/to/reference-photo.png \
+  --prompt-file /path/to/project/thumbnail-prompt.txt \
+  --output /path/to/project/youtube-thumbnail.png
+```
+
+This uses `google/nano-banana-2-lite/edit` at 16:9 and 1K. It uploads the reference image for temporary generation use, submits one generation request, polls the prediction endpoint, and saves `youtube-thumbnail.png` in the project root. Do not claim the script produces native 1280x720 output. Resize the result separately only when the user asks.
 
 ## Step 5. Offer the next move
 
@@ -130,3 +141,5 @@ Tell the user:
 - British English unless voice.md specifies otherwise.
 - If brand-kit.md is in the project, read it and use exact brand colours.
 - Recommend the user keep a consistent thumbnail style across videos for channel recognition.
+- Always keep Gemini as the default provider. Use Atlas Cloud only when the user selects it.
+- Never retry an Atlas Cloud generation POST. Retry only prediction GET requests through the script's bounded polling.

--- a/skills/youtube-thumbnail/scripts/generate_atlas.py
+++ b/skills/youtube-thumbnail/scripts/generate_atlas.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Generate a YouTube thumbnail from a reference photo through Atlas Cloud."""
+
+import argparse
+import json
+import mimetypes
+import os
+import secrets
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+API_BASE = "https://api.atlascloud.ai"
+MODEL = "google/nano-banana-2-lite/edit"
+
+
+def request_json(url, api_key, method="GET", body=None, content_type=None):
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {api_key}"}
+    if content_type:
+        headers["Content-Type"] = content_type
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"Atlas Cloud request failed with HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Atlas Cloud request failed: {exc}") from exc
+    if payload.get("code") not in (0, 200):
+        message = payload.get("message") or payload.get("msg") or "unknown error"
+        raise RuntimeError(f"Atlas Cloud API error: {message}")
+    return payload
+
+
+def upload_reference(path, api_key):
+    source = Path(path)
+    if not source.is_file():
+        raise RuntimeError(f"Reference image not found: {path}")
+    boundary = f"----thumbnail-{secrets.token_hex(16)}"
+    media_type = mimetypes.guess_type(source.name)[0] or "application/octet-stream"
+    body = b"".join(
+        [
+            f"--{boundary}\r\n".encode(),
+            f'Content-Disposition: form-data; name="file"; filename="{source.name}"\r\n'.encode(),
+            f"Content-Type: {media_type}\r\n\r\n".encode(),
+            source.read_bytes(),
+            f"\r\n--{boundary}--\r\n".encode(),
+        ]
+    )
+    payload = request_json(
+        f"{API_BASE}/api/v1/model/uploadMedia",
+        api_key,
+        method="POST",
+        body=body,
+        content_type=f"multipart/form-data; boundary={boundary}",
+    )
+    url = payload.get("data", {}).get("download_url")
+    if not isinstance(url, str) or not url.startswith("https://"):
+        raise RuntimeError("Atlas Cloud upload did not return an HTTPS URL")
+    return url
+
+
+def output_url(data):
+    outputs = data.get("outputs")
+    if isinstance(outputs, list) and outputs and isinstance(outputs[0], str):
+        return outputs[0]
+    return data.get("output") if isinstance(data.get("output"), str) else None
+
+
+def download_image(url, output_path):
+    if not url.startswith("https://"):
+        raise RuntimeError("Atlas Cloud returned a non-HTTPS output URL")
+    destination = Path(output_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            destination.write_bytes(response.read())
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError(f"Unable to download generated thumbnail: {exc}") from exc
+    return str(destination)
+
+
+def generate(prompt, reference_path, output_path, api_key, max_polls=60):
+    reference_url = upload_reference(reference_path, api_key)
+    request_body = json.dumps(
+        {
+            "model": MODEL,
+            "prompt": prompt,
+            "images": [reference_url],
+            "aspect_ratio": "16:9",
+            "resolution": "1k",
+        }
+    ).encode("utf-8")
+
+    # Generation POSTs are intentionally never retried.
+    submitted = request_json(
+        f"{API_BASE}/api/v1/model/generateImage",
+        api_key,
+        method="POST",
+        body=request_body,
+        content_type="application/json",
+    )
+    data = submitted.get("data", {})
+    immediate_url = output_url(data)
+    if data.get("status") == "completed" and immediate_url:
+        return download_image(immediate_url, output_path)
+
+    prediction_id = data.get("id")
+    if not isinstance(prediction_id, str) or not prediction_id:
+        raise RuntimeError("Atlas Cloud response did not include a prediction id")
+    for _ in range(max_polls):
+        time.sleep(3)
+        result = request_json(
+            f"{API_BASE}/api/v1/model/prediction/{prediction_id}", api_key
+        ).get("data", {})
+        if result.get("status") == "completed":
+            url = output_url(result)
+            if not url:
+                raise RuntimeError("Atlas Cloud completed without an output URL")
+            return download_image(url, output_path)
+        if result.get("status") == "failed":
+            raise RuntimeError(
+                f"Atlas Cloud generation failed: {result.get('error', 'unknown error')}"
+            )
+    raise RuntimeError("Atlas Cloud generation timed out while polling")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference", required=True, help="Reference portrait path")
+    parser.add_argument(
+        "--prompt-file", required=True, help="Approved prompt text file"
+    )
+    parser.add_argument("--output", default="youtube-thumbnail.png")
+    parser.add_argument("--api-key", help="Overrides ATLASCLOUD_API_KEY")
+    args = parser.parse_args()
+    api_key = args.api_key or os.environ.get("ATLASCLOUD_API_KEY")
+    if not api_key:
+        parser.error("pass --api-key or set ATLASCLOUD_API_KEY")
+    prompt = Path(args.prompt_file).read_text(encoding="utf-8").strip()
+    if not prompt:
+        parser.error("prompt file is empty")
+    print(generate(prompt, args.reference, args.output, api_key))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_youtube_thumbnail_atlas.py
+++ b/tests/test_youtube_thumbnail_atlas.py
@@ -1,0 +1,98 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "youtube-thumbnail"
+    / "scripts"
+    / "generate_atlas.py"
+)
+SPEC = importlib.util.spec_from_file_location("generate_atlas", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class AtlasThumbnailTest(unittest.TestCase):
+    def test_generation_posts_once_then_polls_get(self):
+        calls = []
+        responses = iter(
+            [
+                {"code": 200, "data": {"id": "p1", "status": "starting"}},
+                {"code": 200, "data": {"id": "p1", "status": "processing"}},
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "completed",
+                        "outputs": ["https://example.com/out.png"],
+                    },
+                },
+            ]
+        )
+
+        def request(url, api_key, method="GET", body=None, content_type=None):
+            calls.append((method, body))
+            return next(responses)
+
+        with (
+            mock.patch.object(
+                MODULE, "upload_reference", return_value="https://example.com/in.png"
+            ),
+            mock.patch.object(MODULE, "request_json", side_effect=request),
+            mock.patch.object(MODULE, "download_image", return_value="thumbnail.png"),
+            mock.patch.object(MODULE.time, "sleep"),
+        ):
+            result = MODULE.generate(
+                "prompt", "face.png", "thumbnail.png", "key", max_polls=2
+            )
+
+        self.assertEqual(result, "thumbnail.png")
+        self.assertEqual([method for method, _ in calls], ["POST", "GET", "GET"])
+        payload = json.loads(calls[0][1])
+        self.assertEqual(payload["images"], ["https://example.com/in.png"])
+        self.assertEqual(payload["aspect_ratio"], "16:9")
+        self.assertEqual(payload["resolution"], "1k")
+
+    def test_upload_requires_https_url(self):
+        with tempfile.NamedTemporaryFile(suffix=".png") as image:
+            image.write(b"image")
+            image.flush()
+            with mock.patch.object(
+                MODULE,
+                "request_json",
+                return_value={
+                    "code": 200,
+                    "data": {"download_url": "http://example.com/in.png"},
+                },
+            ):
+                with self.assertRaisesRegex(RuntimeError, "HTTPS"):
+                    MODULE.upload_reference(image.name, "key")
+
+    def test_polling_is_bounded(self):
+        with (
+            mock.patch.object(
+                MODULE, "upload_reference", return_value="https://example.com/in.png"
+            ),
+            mock.patch.object(
+                MODULE,
+                "request_json",
+                side_effect=[
+                    {"code": 200, "data": {"id": "p1", "status": "starting"}},
+                    {"code": 200, "data": {"id": "p1", "status": "processing"}},
+                ],
+            ),
+            mock.patch.object(MODULE.time, "sleep"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "timed out"):
+                MODULE.generate(
+                    "prompt", "face.png", "thumbnail.png", "key", max_polls=1
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds Atlas Cloud as an optional executable provider for the existing YouTube thumbnail skill. Gemini remains the default workflow.

## Changes made

- add a standard-library Atlas script for reference upload, one-shot generation submission, bounded prediction polling, and output download
- document the opt-in provider workflow and its 1K limitation
- add focused tests for request shape, HTTPS upload validation, and bounded polling

## Testing done

- `python3 -m unittest tests/test_youtube_thumbnail_atlas.py -v` (3 passed)
- `./validate-skills.sh` (17 skills, 0 failures)
- `ruff check` and `ruff format`
- `python3 -m compileall`
- live Atlas model catalogue and schema verified; no paid generation request submitted

## Checklist

- [x] Enhancement to existing skill
- [x] Gemini default remains unchanged
- [x] Documentation updated
- [x] Automated tests added
- [x] No secrets or user-specific paths

## AI assistance

Codex assisted with the implementation. I reviewed the diff and test results.