### PR TITLE
fix(marketplace): make manifest validate against the current schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,30 +7,37 @@
   "plugins": [
     {
       "name": "social-media-skills",
-      "source": ".",
+      "source": "./",
       "description": "The complete set of Claude skills behind Charlie Hills' content system. 415k+ followers across LinkedIn, Instagram, Substack, X and YouTube. 100m+ views per year. 17 skills covering voice, LinkedIn, Instagram Reels, YouTube thumbnails, analytics, and community.",
       "version": "1.0.0",
-      "metadata": {
-        "categories": [
-          "voice",
-          "linkedin",
-          "reels",
-          "youtube",
-          "analytics",
-          "community"
-        ],
-        "tags": [
-          "content creation",
-          "linkedin growth",
-          "instagram reels",
-          "infographics",
-          "gemini",
-          "apify",
-          "elevenlabs",
-          "heygen",
-          "remotion"
-        ]
-      }
+      "author": {
+        "name": "Charlie Hills",
+        "url": "https://charliehills.substack.com"
+      },
+      "category": "productivity",
+      "homepage": "https://github.com/charlie947/social-media-skills",
+      "keywords": [
+        "content creation",
+        "linkedin growth",
+        "instagram reels",
+        "infographics",
+        "gemini",
+        "apify",
+        "elevenlabs",
+        "heygen",
+        "remotion"
+      ],
+      "tags": [
+        "voice",
+        "linkedin",
+        "reels",
+        "youtube",
+        "analytics",
+        "community"
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "description": "Charlie Hills' social media content system: 17 Claude skills for voice, LinkedIn, Instagram Reels, YouTube and analytics."
+  }
 }


### PR DESCRIPTION
## The problem

`claude plugin install social-media-skills` fails:

```
✘ Failed to install plugin "social-media-skills": Plugin "social-media-skills" not found in any configured marketplace
```

Confusingly, `marketplace add` succeeds and the repo clones fine — the marketplace just resolves to zero valid plugins, so the install can't find one.

`claude plugin validate .` shows why:

```
✘ Found 2 errors:

  ❯ plugins.0.source: Invalid input
  ❯ plugins.0: Unrecognized key: "metadata"
```

## The fix

| Field | Before | After |
|---|---|---|
| `source` | `"."` | `"./"` |
| `metadata.tags` | inside `metadata` | `keywords` |
| `metadata.categories` | inside `metadata` | `tags` |

A bare `"."` is rejected; `"./"` is the accepted form for a plugin living at the repo root. `metadata` isn't a recognized plugin key — its contents move to keys the schema does accept, so nothing is lost.

Also filled in `author`, `category` and `homepage`, and added the marketplace description under `metadata.description` at the root, which clears the remaining validation warning.

## Verified end to end

Not just against the validator — the whole install path:

```
$ claude plugin validate .
✔ Validation passed

$ claude plugin marketplace add <this repo>
✔ Successfully added marketplace: social-media-skills

$ claude plugin install social-media-skills@social-media-skills
✔ Successfully installed plugin: social-media-skills@social-media-skills (scope: user)
```

**No skill files are touched** — this only changes `.claude-plugin/marketplace.json`.

Thanks for publishing these, by the way. Found the repo while setting up a content system and hit this on the first install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)