### PR TITLE
feat: platform-agnostic skills + optional Dopa layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Social Media Skills for AI Agents
 
-The complete set of Claude skills behind Charlie Hills' content system. 415k+ followers across LinkedIn, Instagram, Substack, X and YouTube. 100m+ views per year. All running through one system that starts with the newsletter and flows out to every other channel.
+The complete set of skills behind Charlie Hills' content system. 415k+ followers across LinkedIn, Instagram, Substack, X and YouTube. 100m+ views per year. All running through one system that starts with the newsletter and flows out to every other channel.
 
 Built by [Charlie Hills](https://charliehills.substack.com). Subscribe to the [MarTech AI newsletter](https://charliehills.substack.com) for weekly breakdowns of how this system works in practice.
 
@@ -12,7 +12,13 @@ Built by [Charlie Hills](https://charliehills.substack.com). Subscribe to the [M
 
 ## What are Skills?
 
-Skills are markdown files that give AI agents specialised knowledge and workflows for specific tasks. When you install these in your project, Claude recognises when you're working on a social media task and applies the right patterns, voice rules, and platform constraints.
+Skills are markdown files that give AI agents specialised knowledge and workflows for specific tasks. When you install these in your project, your agent recognises when you're working on a social media task and applies the right patterns, voice rules, and platform constraints.
+
+## Platform support
+
+These skills are platform-agnostic. They are written for any capable LLM agent (Claude, Gemini, DeepSeek, OpenRouter models, and others), not just Claude. Where a skill needs a capability like an interactive question form or browser automation, it names Claude's tool as one example and falls back to plain chat or web search when that tool is not present.
+
+Teams running on the [Dopa](https://dopa.solutions) platform can wire the skills to native tools (publish, image generation, brand assets, analytics) through an **optional** adapter. See [dopa-adaptation.md](dopa-adaptation.md) and the "Dopa integration (optional)" section at the bottom of each skill. The adapter is additive: it changes nothing for Claude or any other agent.
 
 ## How Skills Work Together
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,14 @@
 # Versions
 
+## Unreleased
+
+Platform-agnostic pass. All 17 skills now work on any capable LLM agent, not just Claude.
+
+- Replaced Claude-only assumptions with generic agent language: `AskUserQuestion` is now offered as one example with a plain-chat fallback, "Cowork project" reads as "project or workspace", "Claude for Chrome" reads as "any browser-automation capability", and surface names in content-matrix and analytics-dashboard describe agent capabilities rather than named products.
+- Made voice-file lookups configurable: skills scan for equivalents when the default `about-me.md` / `voice.md` names are not used.
+- pinned-comment de-branded from Claude/Anthropic specifics to generic "AI tool" while keeping the joke structure.
+- Added an optional Dopa adapter: a "Dopa integration (optional)" section in each skill plus a master mapping in `dopa-adaptation.md`. Additive only, changes nothing for Claude.
+
 ## 1.0.0 — 2026-04-22
 
 Initial release. 17 skills covering the full content system documented in the MarTech AI newsletter.

--- a/dopa-adaptation.md
+++ b/dopa-adaptation.md
@@ -1,0 +1,45 @@
+# Dopa integration (optional)
+
+These skills are platform-agnostic. They run on any capable LLM agent (Claude, Gemini, DeepSeek, OpenRouter models, and others) with no external product required.
+
+This file documents an **optional** adapter for teams running on the [Dopa](https://dopa.solutions) platform. It maps Dopa's native tools onto each skill so an agent with those tools can act directly (publish, generate images, read brand assets, read analytics) instead of handing prompts back to the user.
+
+Nothing here changes how the skills behave on Claude or any other agent. If the Dopa tools are not present, ignore this file: every skill works unchanged.
+
+## Dopa tools
+
+| Tool | What it does |
+|---|---|
+| `publish_social_post` | Publish a post or comment to LinkedIn, Instagram, or X |
+| `create_canva_design` / `generate_ad_creative` | Render an image or creative from a prompt |
+| `get_brand_assets` | Read the tenant's brand colours, logo, fonts, tone words |
+| `get_analytics` / `analyze_campaigns` | Read post and campaign performance metrics |
+
+## Mapping per skill
+
+| Skill | Dopa tools | How it helps |
+|---|---|---|
+| voice-builder | `get_brand_assets` | Seed about-me.md and voice.md from the tenant's brand voice. Confirm with the user. |
+| newsletter-voice | `get_brand_assets` | Tune archetype defaults with the tenant's tone and pillars. |
+| profile-optimizer | `get_brand_assets`, `create_canva_design` / `generate_ad_creative` | Fill the visual brief with real brand colours and render the 4 profile images. |
+| post-writer | `get_brand_assets`, `publish_social_post` | Reinforce voice with brand terms, then publish the approved post. |
+| post-formatter | `publish_social_post` | Publish the finished framework post. |
+| graphic-designer | `get_brand_assets`, `create_canva_design` / `generate_ad_creative` | Use real brand colours and render the graphic directly. |
+| post-scorer | `get_analytics` / `analyze_campaigns` | Build the scoring profile from real performance instead of an Apify scrape. |
+| hook-generator | none direct | Hooks feed post-writer / post-formatter, which publish via `publish_social_post`. |
+| content-matrix | `analyze_campaigns` | Rank matrix cells by what has performed for the tenant. |
+| niche-research | none direct | Any output row feeds post-writer / post-formatter, which publish via `publish_social_post`. |
+| gemini-infographic | `get_brand_assets`, `create_canva_design` / `generate_ad_creative` | Use real brand colours and render the infographic. |
+| gemini-carousel | `get_brand_assets`, `create_canva_design` / `generate_ad_creative` | Use real brand colours and render each slide. |
+| quote-post | `create_canva_design` / `generate_ad_creative`, `publish_social_post` | Render the quote graphic and publish it. |
+| reels-scripting | `create_canva_design` / `generate_ad_creative`, `publish_social_post` | Render a Reel cover and publish the Reel and caption. |
+| youtube-thumbnail | `get_brand_assets`, `create_canva_design` / `generate_ad_creative` | Use real brand colours and render the thumbnail. |
+| pinned-comment | `create_canva_design` / `generate_ad_creative`, `publish_social_post` | Render the image and post the comment as the first comment. |
+| analytics-dashboard | `get_analytics` / `analyze_campaigns` | Build the dashboard from live metrics instead of an uploaded export. |
+
+## Rules for the optional layer
+
+- Always confirm the target channel and show the final text or image before calling `publish_social_post`.
+- Treat anything from `get_brand_assets` as a draft the user confirms, not a final decision.
+- Never invent metrics. If `get_analytics` cannot fill a panel or a fix, say so rather than guessing.
+- If a Dopa tool is unavailable, fall back to the skill's default behaviour (output the prompt, save the file, ask the user).

--- a/skills/analytics-dashboard/SKILL.md
+++ b/skills/analytics-dashboard/SKILL.md
@@ -34,7 +34,7 @@ Clean any messy headers. Merge the two TOP POSTS tables (by engagements and by i
 
 ## Step 3. Build the interactive dashboard
 
-Create a single React artifact. Dark theme (background `#0f1117`), accent colours for charts. Use Recharts for all visualisations.
+Create a single self-contained interactive React dashboard. Render it as an artifact if your agent supports them; otherwise write a standalone file (for example `linkedin-dashboard.html` or a `.jsx` file) the user can open. Dark theme (background `#0f1117`), accent colours for charts. Use Recharts for all visualisations.
 
 Include these panels in this order:
 
@@ -133,3 +133,9 @@ After the analysis:
 - Never use em dashes.
 - British English unless voice.md specifies otherwise.
 - Recommend running this monthly. Patterns only surface over time.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_analytics` / `analyze_campaigns` — pull the tenant's metrics directly to build the dashboard instead of the user uploading a LinkedIn Analytics export. Flag any panels the returned data cannot fill rather than inventing figures.

--- a/skills/content-matrix/SKILL.md
+++ b/skills/content-matrix/SKILL.md
@@ -20,7 +20,7 @@ If about-me.md is missing, ask:
 
 Wait for response.
 
-Then call AskUserQuestion:
+Then ask the user about their content pillars. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask in chat with the same options:
 
 ```json
 [
@@ -73,11 +73,11 @@ Each cell's idea should be a specific headline, not a theme. Good: "The 3-line h
 
 ## Step 3. Output (surface-aware)
 
-Pick the output mode based on the surface you are running on. Do not output the table in a fenced markdown code block — that renders as monospace plain text and makes a 5×8 grid hard to scan.
+Pick the output mode based on the capabilities your agent has. Do not output the table in a fenced markdown code block — that renders as monospace plain text and makes a 5×8 grid hard to scan.
 
-- **Claude.ai or Claude Cowork (chat surfaces with interactive chart support):** render the matrix as an interactive chart / interactive table widget. Pillars as rows, formats as columns, each cell holding one specific headline. The user should be able to click a cell to see the full headline and any expansion notes. Do not also dump the table as markdown — the chart is the deliverable.
-- **Claude Code (file-system surface, has Write/Edit tools):** save the matrix to `content-matrix-YYYY-MM-DD.md` in the current working directory and print the same table inline in the response as a plain markdown table (no triple-backtick wrap). Confirm the file path so the user can open it.
-- **Fallback (no interactive chart, no file-system tools):** output a plain markdown table inline. Still no code-fence wrap.
+- **Agent can render interactive charts or tables (e.g. a chat surface with widget support):** render the matrix as an interactive chart / interactive table widget. Pillars as rows, formats as columns, each cell holding one specific headline. The user should be able to click a cell to see the full headline and any expansion notes. Do not also dump the table as markdown — the widget is the deliverable.
+- **Agent can write files (has file-system or write/edit tools):** save the matrix to `content-matrix-YYYY-MM-DD.md` in the current working directory and print the same table inline in the response as a plain markdown table (no triple-backtick wrap). Confirm the file path so the user can open it.
+- **Fallback (no interactive widget, no file-system tools):** output a plain markdown table inline. Still no code-fence wrap.
 
 Below the table or chart, add one sentence naming the single strongest idea across the matrix and why.
 
@@ -87,7 +87,7 @@ Ask:
 
 > Any cell here you want me to write as a full post? Reference the cell by pillar + format (for example "Hooks × Contrarian") and I will hand it to the post-writer or post-formatter skill.
 
-On Claude Code, also offer to append the drafted post into the same `content-matrix-YYYY-MM-DD.md` file under the cell reference.
+If your agent can write files, also offer to append the drafted post into the same `content-matrix-YYYY-MM-DD.md` file under the cell reference.
 
 ## Rules
 
@@ -96,3 +96,9 @@ On Claude Code, also offer to append the drafted post into the same `content-mat
 - Tune the language to the user's voice if voice.md exists.
 - British English unless voice.md specifies American.
 - Never use em dashes.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `analyze_campaigns` — rank the matrix cells by which pillars and formats have performed for the tenant, so the "single strongest idea" call in Step 3 is data-backed rather than a guess.

--- a/skills/gemini-carousel/SKILL.md
+++ b/skills/gemini-carousel/SKILL.md
@@ -16,7 +16,7 @@ Ask:
 
 > Paste the content you want in the carousel. A post, section of a newsletter, research notes, or a framework all work.
 
-Wait for the content, then call AskUserQuestion:
+Wait for the content, then ask the user the questions below. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask them in chat with the same options:
 
 ```json
 [
@@ -119,3 +119,10 @@ After the per-slide prompts, offer:
 - Never use em dashes.
 - British English unless voice.md specifies otherwise.
 - If brand-kit.md exists in the project, read it and use its exact hex codes and typography choices.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's brand colours and typography for the slide prompts instead of reading brand-kit.md.
+- `create_canva_design` / `generate_ad_creative` — render the per-slide prompts directly instead of the user pasting each one into an external image generator.

--- a/skills/gemini-infographic/SKILL.md
+++ b/skills/gemini-infographic/SKILL.md
@@ -78,3 +78,10 @@ After the prompt, offer:
 - Always wait for user approval of the brief before outputting the final prompt.
 - British English unless voice.md says otherwise.
 - If the user has brand-kit.md or colours.md in the project, bake their brand colours into the visual suggestions.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's brand colours for the visual suggestions instead of reading brand-kit.md.
+- `create_canva_design` / `generate_ad_creative` — render the infographic prompt directly instead of the user pasting it into an external image generator.

--- a/skills/graphic-designer/SKILL.md
+++ b/skills/graphic-designer/SKILL.md
@@ -16,7 +16,7 @@ Check the project for the most recent post file. If found, read it. If not, say:
 
 > Paste the post you want a graphic for.
 
-Wait for the post, then call AskUserQuestion:
+Wait for the post, then ask the user which style they want. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask in chat with the same options:
 
 ```json
 [
@@ -26,8 +26,8 @@ Wait for the post, then call AskUserQuestion:
     "multiSelect": false,
     "options": [
       {"label": "HTML/CSS graphic", "description": "Clean structured layout. Framework, comparison, steps, data. Fully editable, screenshot to export."},
-      {"label": "Whiteboard infographic", "description": "Hand-drawn marker style on a whiteboard or notebook page. Recaps the post visually. Generated in Gemini."},
-      {"label": "Branded infographic", "description": "Professional infographic using your brand colours. Recaps the post visually. Generated in Gemini."},
+      {"label": "Whiteboard infographic", "description": "Hand-drawn marker style on a whiteboard or notebook page. Recaps the post visually. Generated in an image model such as Gemini."},
+      {"label": "Branded infographic", "description": "Professional infographic using your brand colours. Recaps the post visually. Generated in an image model such as Gemini."},
       {"label": "You decide", "description": "Analyse the post and pick the best format automatically"}
     ]
   }
@@ -147,3 +147,10 @@ Say:
 - Branded style: always clean, flat, modern, using the user's brand colours.
 - Never use em dashes in any output.
 - British English throughout.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's brand colours and fonts for Path A (HTML/CSS) and the branded infographic instead of asking for hex codes.
+- `create_canva_design` / `generate_ad_creative` — render the Path B image prompt directly instead of the user pasting it into an external image generator.

--- a/skills/hook-generator/SKILL.md
+++ b/skills/hook-generator/SKILL.md
@@ -87,3 +87,9 @@ Ask:
 - Prefer digits over spelled numbers (3, not three).
 - British English unless voice.md says otherwise.
 - Never hedge. A weak hook is worse than no hook.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- No direct Dopa tool. Hooks feed the post-writer or post-formatter skill, which can then publish via `publish_social_post`.

--- a/skills/newsletter-voice/SKILL.md
+++ b/skills/newsletter-voice/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: newsletter-voice
 description: >
-  Build newsletter writing instructions inside a Cowork project. Runs after voice-builder. Produces newsletter-voice.md, a single file Claude references when drafting newsletters in the user's voice. Works with or without existing newsletter samples: if the user has past issues, the skill analyses them; if not, the skill offers 6 archetypes tuned to the user's voice. Trigger whenever the user says "build my newsletter voice", "learn my newsletter style", "set up my newsletter system", "train on my newsletters", "newsletter onboarding", or drops newsletter samples into chat asking for an analysis. Requires voice-builder to have run first: the skill needs voice.md and about-me.md in the project to work.
+  Build newsletter writing instructions inside your project or workspace. Works with any LLM agent. Runs after voice-builder. Produces newsletter-voice.md, a single file the agent references when drafting newsletters in the user's voice. Works with or without existing newsletter samples: if the user has past issues, the skill analyses them; if not, the skill offers 6 archetypes tuned to the user's voice. Trigger whenever the user says "build my newsletter voice", "learn my newsletter style", "set up my newsletter system", "train on my newsletters", "newsletter onboarding", or drops newsletter samples into chat asking for an analysis. Requires voice-builder to have run first: the skill needs the project voice files (about-me.md and voice.md, or the equivalent voice files your project uses) to work.
 ---
 
 # Newsletter Voice
 
 ## Prerequisites check
 
-The moment this skill is triggered, check the project root for voice.md and about-me.md.
+The moment this skill is triggered, check the project root for the voice files. These are usually named voice.md and about-me.md, but a project may use different filenames for the same purpose. Look for those two, and if they are absent, scan for any equivalent voice or about files in the project root before deciding they are missing.
 
-If either file is missing, tell the user:
+If they are genuinely missing, tell the user:
 
-> Newsletter voice sits on top of your general voice profile. Run voice-builder first (upload the skill or say "build my voice"), then come back here once about-me.md and voice.md are in the project.
+> Newsletter voice sits on top of your general voice profile. Run voice-builder first (say "build my voice"), then come back here once your voice files (about-me.md and voice.md) are in the project.
 
-Then stop. Do not continue until both files exist.
+Then stop. Do not continue until the voice files exist.
 
 If both files exist, read them fully, then go straight to Step 1.
 
@@ -83,7 +83,7 @@ Then go to Step 3.
 
 ## Step 2b. Archetype selection
 
-Call the AskUserQuestion tool with a single question:
+Ask the user this question. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask it in chat with the same options:
 
 ```json
 [
@@ -170,3 +170,9 @@ One file in the project root:
 - Do not produce a separate voice or banned-words file. Absence patterns live inside newsletter-voice.md as a single section.
 - British English throughout unless samples are clearly American.
 - Never use em dashes in any output file or in any draft.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's brand tone and messaging pillars to tune the archetype defaults before writing `newsletter-voice.md`. Treat the result as a draft the user confirms.

--- a/skills/niche-research/SKILL.md
+++ b/skills/niche-research/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: niche-research
 description: >
-  Surface the 20 most relevant stories in a niche from the last 7 days using Claude for Chrome. Verified dates, real links, shareable angles. Claude drives the browser to scroll Reddit, X and run Google searches — exactly like a human researcher would. Use this skill whenever the user says "research my niche", "what's trending", "find stories", "this week's news", "content research", or drops a niche and asks what's happening in it. Requires the Claude for Chrome extension to be enabled for live browsing.
+  Surface the 20 most relevant stories in a niche from the last 7 days using live browsing. Verified dates, real links, shareable angles. The agent drives a browser to scroll Reddit, X and run Google searches, exactly like a human researcher would. Use this skill whenever the user says "research my niche", "what's trending", "find stories", "this week's news", "content research", or drops a niche and asks what's happening in it. Requires a browser-automation capability (a browser extension such as Claude for Chrome, a Playwright MCP server, or any equivalent your agent has); falls back to web search and fetch tools.
 ---
 
 # Niche Research
@@ -12,18 +12,18 @@ When this skill triggers, go straight to Step 1. Do not summarise the research m
 
 ## Prerequisites
 
-This skill needs live browsing. Use this order of preference:
+This skill needs live browsing. Use whichever of these your agent has, in this order of preference:
 
-1. **Claude for Chrome extension** (preferred). Check that the extension is enabled and Claude has permission to browse on the current tab. If not, tell the user:
-   > Enable the Claude for Chrome extension and open a blank tab. I need to drive the browser to scroll Reddit, X, and run Google searches with verified dates.
-2. **Playwright MCP** as a fallback if the Claude for Chrome extension is not available.
-3. **WebSearch + WebFetch tools** as a last resort (less thorough on feed scrolling).
+1. **A browser-automation extension** (preferred), such as Claude for Chrome or any equivalent your agent supports. Check that it is enabled and has permission to browse the current tab. If it is not available or not permitted, tell the user:
+   > I need a browser-automation capability to drive the browser and scroll Reddit, X, and run Google searches with verified dates. Enable your browser extension (for example Claude for Chrome) and open a blank tab, or let me fall back to web search.
+2. **A browser-automation MCP server** (for example Playwright MCP) as a fallback if no extension is available.
+3. **Web search and fetch tools** as a last resort (less thorough on feed scrolling).
 
 Pick the best available path and continue.
 
 ## Step 1. Gather the niche
 
-Call AskUserQuestion:
+Ask the user for the niche. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask in chat with the same options:
 
 ```json
 [
@@ -121,6 +121,12 @@ After the table, ask:
 - Verify every publish date before including an item. No shortcuts.
 - Table only at the end. No commentary, no summary paragraph.
 - If fewer than 20 themes pass the filter, say so. Do not pad with weak items.
-- If Claude for Chrome is not available and neither Playwright MCP nor WebSearch can cover feed scrolling properly (Reddit and X), tell the user what is missing rather than faking the scan.
+- If no browser-automation capability is available and web search cannot cover feed scrolling properly (Reddit and X), tell the user what is missing rather than faking the scan.
 - British English throughout. DD/MM/YYYY date format.
 - Never use em dashes.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- No direct Dopa tool. Any row in the output table can be handed to the post-writer or post-formatter skill, which can then publish via `publish_social_post`.

--- a/skills/pinned-comment/SKILL.md
+++ b/skills/pinned-comment/SKILL.md
@@ -26,8 +26,8 @@ This is why image generation comes FIRST. Always.
 ### Step 1. Find the admission
 
 Every Charlie post hides one quiet confession. Examples:
-- "Cowork does most of my actual job now"
-- "I am embarrassingly dependent on Anthropic"
+- "My AI assistant does most of my actual job now"
+- "I am embarrassingly dependent on my AI tools"
 - "I gave away a 9-month product for free"
 - "I am a sponsored creator who lost objectivity"
 
@@ -38,9 +38,9 @@ Write the admission as one sentence before doing anything else.
 
 Three rules for the image:
 
-1. **One clear visual gag.** The eye lands on it in under a second. Examples that worked: tie draped on a laptop keyboard, a shrine to Anthropic with a rose and candles, a banquet table where every other seat is a tech logo.
+1. **One clear visual gag.** The eye lands on it in under a second. Examples that worked: tie draped on a laptop keyboard, a shrine to the creator's AI tool with a rose and candles, a banquet table where every other seat is a tech logo.
 2. **Played completely straight.** No winking. No thumbs up. No exaggerated faces. The humour comes from treating the absurd as normal.
-3. **Charlie is the lower-status figure.** Always. Claude wins. The logo wins. The mum wins. Charlie loses with quiet dignity.
+3. **Charlie is the lower-status figure.** Always. The AI wins. The logo wins. The mum wins. Charlie loses with quiet dignity.
 
 Use the standard format:
 
@@ -89,12 +89,12 @@ If any test fails, fix before sending.
 
 This is the benchmark. When in doubt, compare new comments against this one.
 
-**The image:** Charlie sitting cross-legged on the floor in striped pyjamas eating cereal from a bowl, looking up at his own desk chair where an open laptop sits with a knotted necktie draped over the keyboard. A framed "Employee of the Month" certificate on the wall has the Claude logo and the name "Claude (Anthropic)" on it. Morning light, played completely straight.
+**The image:** Charlie sitting cross-legged on the floor in striped pyjamas eating cereal from a bowl, looking up at his own desk chair where an open laptop sits with a knotted necktie draped over the keyboard. A framed "Employee of the Month" certificate on the wall carries the logo and name of the AI tool the creator uses. Morning light, played completely straight.
 
 **The comment:**
 
 ```
-📌 Claude wears the tie now.
+📌 The AI wears the tie now.
 I wear the pyjamas.
 The cereal was my idea, at least.
 Small wins where you find them.
@@ -113,9 +113,9 @@ Small wins where you find them.
 ## OTHER PROVEN IMAGE GAGS (for reference)
 
 - **Status reversal at the desk:** Laptop in the chair wearing a tie, Charlie on the floor in pyjamas
-- **The shrine:** Candles, a rose, a framed Anthropic logo, a handwritten letter "To Dario", Charlie kneeling in prayer
+- **The shrine:** Candles, a rose, a framed logo of the creator's AI tool, a handwritten letter addressed to the AI lab, Charlie kneeling in prayer
 - **The banquet table:** Charlie at the head of the table with a paper crown, every other seat occupied by a tech logo (Stanford, Google, OpenAI, Anthropic, Microsoft)
-- **The therapist's couch:** Charlie reclining looking happy, therapist looking concerned, Claude logo framed on the wall behind her
+- **The therapist's couch:** Charlie reclining looking happy, therapist looking concerned, the AI tool's logo framed on the wall behind her
 - **The boardroom:** Charlie pointing at a presentation, every "executive" in the room is a tech logo
 - **The pub vs the home office:** Charlie smug at a pub table while his laptop visibly works through a window across the street
 
@@ -144,3 +144,12 @@ When triggered, always output:
 4. **A one-line note** confirming the comment passed the 5 tests
 
 Optionally provide 2-3 variations if the first attempt is borderline.
+
+---
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `create_canva_design` / `generate_ad_creative` — render the image prompt directly instead of the user pasting it into an external image generator.
+- `publish_social_post` — post the 4-line comment as the first comment on the published LinkedIn post once the user approves.

--- a/skills/post-formatter/SKILL.md
+++ b/skills/post-formatter/SKILL.md
@@ -12,7 +12,7 @@ When this skill triggers, go straight to Step 1. Do not summarise. Start input g
 
 ## Step 1. Gather inputs
 
-Call AskUserQuestion:
+Ask the user the questions below. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask them in chat with the same options:
 
 ```json
 [
@@ -96,3 +96,9 @@ After the post, ask:
 - British English unless voice.md specifies otherwise.
 - If the user has voice.md in the project, tune tone and rhythm to match it.
 - If a trio is used, it has exactly three items. Not two, not four.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `publish_social_post` — publish the finished post to LinkedIn, Instagram, or X. Confirm the channel and show the final text before publishing.

--- a/skills/post-scorer/SKILL.md
+++ b/skills/post-scorer/SKILL.md
@@ -24,13 +24,13 @@ The scorer needs two things: the user's voice system and real performance data.
 
 ### Voice system
 
-Read about-me.md and voice.md from the project if they exist. If missing, note it and score without voice matching.
+Read about-me.md and voice.md from the project if they exist (or the equivalent voice files your project uses). If missing, note it and score without voice matching.
 
 ### Performance data
 
 Check for cached LinkedIn data in the project or outputs folder. Look for files matching *-all-posts.json or *-posts.txt.
 
-If cached data exists, use it. If not, ask the user:
+If cached data exists, use it. If not, ask the user how to get it (use an interactive multiple-choice tool such as Claude's `AskUserQuestion` if your agent has one, otherwise ask in chat with the same options):
 
 ```json
 [
@@ -188,3 +188,9 @@ Comment gate rate: 5%
 - Never use em dashes in any output.
 - British English throughout.
 - Keep the scorecard compact. It needs to look good on a big screen at events.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_analytics` / `analyze_campaigns` — pull the tenant's real post performance as the scoring profile instead of scraping with Apify. Build the top-10% patterns in Step 3 from this data and cite it in every fix.

--- a/skills/post-writer/SKILL.md
+++ b/skills/post-writer/SKILL.md
@@ -12,9 +12,9 @@ The moment this skill triggers, go straight to Step 1. Do not summarise the skil
 
 ## Step 1. Gather inputs
 
-Check the project for about-me.md and voice.md. Read both. If either is missing, tell the user to run the Voice Builder skill first ("say build my voice"), then stop.
+Check the project for the voice files, usually about-me.md and voice.md (a project may use different filenames for the same purpose, so scan for equivalents before deciding they are missing). Read both. If they are genuinely missing, tell the user to run the voice-builder skill first ("say build my voice"), then stop.
 
-If both files exist, call AskUserQuestion with this exact JSON:
+If both files exist, ask the user the questions below. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask them in chat with the same options:
 
 ```json
 [
@@ -44,7 +44,7 @@ If both files exist, call AskUserQuestion with this exact JSON:
 Based on the answers:
 - "Paste a context dump": wait for the user to paste, extract the core idea, then proceed to Step 2
 - "I have a topic in mind": wait for the user to type it, then proceed to Step 2
-- "Suggest topics for me": read about-me.md topic pillars and voice.md, suggest 5 specific topics with a one-line angle for each, then use AskUserQuestion to let them pick one
+- "Suggest topics for me": read about-me.md topic pillars and voice.md, suggest 5 specific topics with a one-line angle for each, then ask the user to pick one (with an interactive tool such as Claude's `AskUserQuestion` if available, otherwise in chat)
 - "I will paste examples": wait for reference posts, note the structural patterns, then proceed
 - "Use my training posts": reference whatever posts are already in the project
 
@@ -56,7 +56,7 @@ Before writing, research the topic. Look for:
 - Real examples or case studies
 - Common misconceptions to challenge
 
-Then present a post plan. Call AskUserQuestion:
+Then present a post plan. Ask the user to choose (use an interactive tool such as Claude's `AskUserQuestion` if available, otherwise ask in chat):
 
 ```json
 [
@@ -128,3 +128,10 @@ Then say:
 - Do not add engagement bait CTAs unless they appear in voice.md.
 - Keep posts between 150 and 300 words unless the user requests otherwise.
 - Plan before writing. Never skip Step 2.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's tone words and banned terms to reinforce the voice files before drafting.
+- `publish_social_post` — once the user says "ship it", publish the final post to LinkedIn, Instagram, or X instead of only saving it. Always confirm the target channel and show the final text before publishing.

--- a/skills/profile-optimizer/SKILL.md
+++ b/skills/profile-optimizer/SKILL.md
@@ -12,9 +12,9 @@ When this skill triggers, go straight to Step 1. Do not summarise. Do not explai
 
 ## Step 1. Gather inputs
 
-Check the project for about-me.md. If it exists, pre-fill name, audience, topics, and POV from it. Skip those questions and tell the user what you pulled.
+Check the project for about-me.md (or your project's equivalent voice files). If it exists, pre-fill name, audience, topics, and POV from it. Skip those questions and tell the user what you pulled.
 
-Call AskUserQuestion in two batches.
+Ask the user the questions below in two batches. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it to render each batch as a form; otherwise present the questions and options in chat and wait for the answers.
 
 ### Batch 1
 
@@ -114,7 +114,7 @@ Option 2 (Pain-focused): [problem + audience]
 Option 3 (Differentiator): [unique angle + audience]
 ```
 
-Then call AskUserQuestion to let the user pick:
+Then ask the user to pick one (use an interactive tool such as Claude's `AskUserQuestion` if available, otherwise ask in chat):
 
 ```json
 [
@@ -204,7 +204,7 @@ No subtitles. No internal LinkedIn posts. No "DM me" items.
 
 ## Step 6. Visual Design Brief
 
-Output 4 separate image generation prompts, each in its own code block. Each prompt must be fully self-contained and work when pasted into Gemini as a standalone request.
+Output 4 separate image generation prompts, each in its own code block. Each prompt must be fully self-contained and work when pasted into any image generation model (Gemini, or whichever your user prefers) as a standalone request.
 
 State the brand colours at the top:
 - Primary hex: [user-provided or suggested]
@@ -248,7 +248,7 @@ The prompt must:
 
 After all 4 prompts, say:
 
-> Copy each prompt into a new Gemini chat one at a time. For the banner and profile picture, attach your headshot alongside the prompt. The featured tiles do not need a photo.
+> Copy each prompt into your image generator one at a time (Gemini works well). For the banner and profile picture, attach your headshot alongside the prompt. The featured tiles do not need a photo.
 
 ## Rules
 
@@ -261,3 +261,10 @@ After all 4 prompts, say:
 - Never use em dashes.
 - British English throughout.
 - Do NOT offer to write a launch post or engagement strategy after the design brief. End at the design brief.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's brand colours, logo, and fonts to fill the Visual Design Brief instead of asking for hex codes.
+- `create_canva_design` / `generate_ad_creative` — render the 4 image prompts (banner, profile picture, 2 featured tiles) directly instead of the user pasting them into an external image generator.

--- a/skills/quote-post/SKILL.md
+++ b/skills/quote-post/SKILL.md
@@ -84,7 +84,7 @@ Recreate the attached reference image with the following quote:
 Critical constraints:
 - Output at exactly 1080 x 1350 pixels (4:5 vertical)
 - Match the style, typography, and colour palette of the reference image
-- Keep the quote as the focal point — centred and legible
+- Keep the quote as the focal point, centred and legible
 - Attribute nothing (no names, no handles, no logos)
 - Maintain the visual tone of the original but with the new text
 
@@ -93,7 +93,7 @@ The quote must be perfectly spelled and punctuated exactly as written above.
 
 Tell the user:
 
-> Paste this into a new Gemini chat with the reference image attached. Create Image mode, Nano Banana model, 1080x1350 output.
+> Paste this into your image generator with the reference image attached (Gemini works well: Create Image mode, Nano Banana model). Generate at 1080x1350.
 
 ## Step 5. Honest expectation-setting
 
@@ -110,3 +110,10 @@ After the prompt, add:
 - British English unless voice.md specifies otherwise.
 - Tune the quote options to the user's voice if voice.md exists.
 - If the user's voice is explicitly not motivational (analytical, contrarian-only, dry), flag the mismatch and ask if quote posts suit their positioning before generating.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `create_canva_design` / `generate_ad_creative` — render the quote graphic directly instead of the user pasting the prompt into an external image generator.
+- `publish_social_post` — publish the quote graphic and caption to LinkedIn once the user approves.

--- a/skills/reels-scripting/SKILL.md
+++ b/skills/reels-scripting/SKILL.md
@@ -35,7 +35,7 @@ Ask:
 
 Wait for the URL.
 
-If the user pastes a Notion link, follow it via WebFetch, locate the Instagram Reel URL on the page, and extract it. If no Reel URL is found on the Notion page, ask the user to paste the Reel URL directly.
+If the user pastes a Notion link, fetch it with whatever web-fetch capability your agent has, locate the Instagram Reel URL on the page, and extract it. If no Reel URL is found on the Notion page, ask the user to paste the Reel URL directly.
 
 ## Step 2. Get the newsletter topic
 
@@ -188,7 +188,7 @@ After the script is approved, offer:
 > Two paths from here:
 >
 > 1. Record it yourself.
-> 2. Auto-generate with ElevenLabs (voice) + HeyGen (avatar) + Remotion (motion graphics). If you have the my-video project configured, run `npm run pipeline:claude-routines` with this script config.
+> 2. Auto-generate with a text-to-speech tool (voice) + an avatar tool (for example HeyGen) + a motion-graphics renderer (for example Remotion). If you have a video-generation pipeline configured, pass this script config to it.
 
 ## Rules
 
@@ -198,4 +198,11 @@ After the script is approved, offer:
 - British English. No em dashes. No semicolons.
 - Every script deliverable includes the exact caption and comment trigger alongside the script. Never deliver just the script.
 - If the reference Reel scrape fails across all three actor variants, report the failure and stop. Do not fabricate analysis.
-- Gemini 2.5 Flash is the model. Do not substitute without the user's approval.
+- Gemini 2.5 Flash is the video-analysis model. Do not substitute without the user's approval.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `create_canva_design` / `generate_ad_creative` — produce a Reel cover or thumbnail from the hook once the script is approved.
+- `publish_social_post` — publish the finished Reel and caption to Instagram. Confirm the caption and comment trigger before publishing.

--- a/skills/voice-builder/SKILL.md
+++ b/skills/voice-builder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: voice-builder
 description: >
-  Build a personalised voice profile inside a Cowork project from a short interview plus 3 to 5 sample pieces of writing. Works for any content format: LinkedIn posts, newsletters, essays, emails, blog posts, tweets, or any other published writing. Use this skill at the start of any Cowork project where the user wants Claude to learn who they are and how they write before drafting new content. Trigger whenever the user says "build my voice", "learn my voice", "set up my content system", "onboard me", "train on my writing", "train on my posts", "I want Claude to sound like me", or drops a batch of writing samples into chat at the start of a project. Also trigger for first-time Cowork users who need a voice foundation before writing anything. Always produces two files (about-me.md and voice.md) saved into the project root.
+  Build a personalised voice profile inside your project or workspace from a short interview plus 3 to 5 sample pieces of writing. Works for any content format: LinkedIn posts, newsletters, essays, emails, blog posts, tweets, or any other published writing. Works with any LLM agent. Use this skill at the start of any project where the user wants the agent to learn who they are and how they write before drafting new content. Trigger whenever the user says "build my voice", "learn my voice", "set up my content system", "onboard me", "train on my writing", "train on my posts", "I want you to sound like me", "I want the AI to sound like me", or drops a batch of writing samples into chat at the start of a project. Also trigger for first-time users who need a voice foundation before writing anything. Always produces two files (about-me.md and voice.md) saved into the project root.
 ---
 
 # Voice Builder
@@ -27,13 +27,13 @@ This applies whether the user uploaded a .skill file, said "build my voice", pas
 
 ## Step 1. Run the About Me interview
 
-You MUST call the AskUserQuestion tool to ask these questions. Do not type the questions as chat text. Use the tool. The tool renders as an interactive form the user fills in, which is a better experience than typing answers into chat.
+Ask the user these questions. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it to render them as a form, which is a better experience than typing answers into chat. If it does not, present the questions and options in chat as a numbered list and wait for the answers.
 
-AskUserQuestion supports a maximum of 4 questions per call, so send two calls: Batch 1 first, wait for answers, then Batch 2.
+Send the questions in two batches (some interactive tools cap at 4 questions per call): Batch 1 first, wait for answers, then Batch 2.
 
 ### Batch 1 (your very first action, no text before it)
 
-Call AskUserQuestion with this exact JSON structure for the questions parameter:
+Use this exact question set (the JSON below is ready for an interactive tool; in chat, ask the same questions and offer the same options):
 
 ```json
 [
@@ -85,7 +85,7 @@ Call AskUserQuestion with this exact JSON structure for the questions parameter:
 
 ### Batch 2 (send immediately after Batch 1 answers come back, no commentary between)
 
-Call AskUserQuestion again with:
+Ask the next set the same way:
 
 ```json
 [
@@ -140,7 +140,7 @@ Create about-me.md in the project root. Use this structure:
 [From question 6, topics or angles never to write about]
 ```
 
-Keep it under 300 words. Every line should be something Claude would reference when writing.
+Keep it under 300 words. Every line should be something the agent would reference when writing.
 
 ## Step 3. Ask for the samples
 
@@ -255,4 +255,10 @@ Two files in the project root:
 - Keep voice.md under 500 words.
 - British English throughout unless the samples are clearly American.
 - Never use em dashes in any output file or in any draft.
-- Do not produce an voice.md file. Absence signals live inside voice.md.
+- Do not produce a separate absence-signals file. Absence signals live inside voice.md.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it entirely if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's brand voice notes, tone words, and banned terms to seed `about-me.md` and `voice.md` before the interview. Treat anything returned as a starting draft the user confirms, never as final.

--- a/skills/youtube-thumbnail/SKILL.md
+++ b/skills/youtube-thumbnail/SKILL.md
@@ -22,7 +22,7 @@ If a reference photo path is stored, pre-fill it. Otherwise ask:
 
 > Upload or provide the path to the reference photo of yourself you want used in the thumbnail. Ideally a clear headshot with distinctive lighting and expression you plan to reuse across videos for brand consistency.
 
-Then call AskUserQuestion:
+Then ask the user the questions below. If your agent has an interactive multiple-choice tool (for example Claude's `AskUserQuestion`), use it; otherwise ask them in chat with the same options:
 
 ```json
 [
@@ -114,7 +114,7 @@ Constraints:
 
 Tell the user:
 
-> Paste this into a new Gemini chat, attach your reference photo, enable Create Image, and select Nano Banana. Generate at 1280x720.
+> Paste this into your image generator and attach your reference photo (Gemini works well: enable Create Image and select Nano Banana). Generate at 1280x720.
 
 ## Step 5. Offer the next move
 
@@ -130,3 +130,10 @@ Tell the user:
 - British English unless voice.md specifies otherwise.
 - If brand-kit.md is in the project, read it and use exact brand colours.
 - Recommend the user keep a consistent thumbnail style across videos for channel recognition.
+
+## Dopa integration (optional)
+
+Additive layer for Dopa users. Skip it if you run this on Claude or any other agent: the skill works unchanged without it.
+
+- `get_brand_assets` — pull the tenant's brand colours for the thumbnail palette instead of reading brand-kit.md.
+- `create_canva_design` / `generate_ad_creative` — render the thumbnail prompt directly instead of the user pasting it into an external image generator.


### PR DESCRIPTION
## Resumen

Este PR hace que los 17 skills sean **agnósticos de plataforma**: funcionan con cualquier agente LLM capaz (Claude, Gemini, DeepSeek, modelos vía OpenRouter, etc.), sin romper el uso actual en Claude. Añade además una **capa opcional y aditiva** para equipos que corren sobre la plataforma Dopa.

No cambia los triggers (campo `description`), los formatos de salida ni la esencia de ningún skill. `validate-skills.sh` pasa con **0 fallos y 0 warnings** (17 skills).

## Qué se de-Claudificó

- **`AskUserQuestion`**: ahora se menciona como *un ejemplo* de herramienta interactiva, con fallback explícito a preguntar en el chat. Cualquier agente sin esa tool sigue el skill igual (9 skills).
- **"Cowork project"** → "project or workspace" (voice-builder, newsletter-voice).
- **niche-research**: "Claude for Chrome" se generaliza a "cualquier capacidad de automatización de navegador"; se mantienen Playwright MCP y web search como fallbacks.
- **content-matrix** y **analytics-dashboard**: las superficies nombradas (Claude.ai / Claude Cowork / Claude Code / "React artifact") pasan a describirse por *capacidad del agente* (puede renderizar widgets / puede escribir archivos / fallback).
- **reels-scripting**: el handoff a `npm run pipeline:claude-routines` / `my-video` se generaliza a "un pipeline de generación de vídeo"; TTS/avatar/motion se nombran como categorías (con HeyGen/Remotion como ejemplos).
- **pinned-comment**: se quitan referencias a Claude/Anthropic/Dario dejando "the AI tool" genérico, conservando la estructura del chiste y el gold-standard example.
- **Archivos de voz configurables**: los skills que leen `about-me.md` / `voice.md` ahora buscan equivalentes si el proyecto usa otros nombres, y explican cómo generarlos con voice-builder si faltan.

Las referencias a Gemini / Nano Banana en los skills de imagen se conservan como herramienta recomendada, pero el texto ya no asume que sea la única opción ("your image generator, such as Gemini").

## Capa opcional de Dopa (no afecta a Claude)

- Cada skill incluye al final una sección **"Dopa integration (optional)"** que mapea las tools de Dopa: `publish_social_post`, `create_canva_design` / `generate_ad_creative`, `get_brand_assets`, `get_analytics` / `analyze_campaigns`.
- Se añade **`dopa-adaptation.md`** con la tabla de mapeo completa por skill y las reglas del adaptador.
- Es **aditiva**: si esas tools no están presentes, el skill funciona exactamente igual que antes. Marcada como opcional en todos lados.

> Nota de estilo: por consistencia con el resto del repo (British English), las secciones y el doc de Dopa están escritos en inglés, aunque el encabezado interno se puede ajustar a preferencia del mantenedor. Si preferís que la capa Dopa se retire del PR upstream y quede sólo en el fork, se puede separar en un commit aparte sin problema.

## Verificación

```
bash validate-skills.sh
# Skills checked: 17 | Passed: 87 | Warnings: 0 | Failed: 0
```