### PR TITLE
feat: add post-publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See each skill's `SKILL.md` for trigger phrases, inputs, and dependencies.
 | [gemini-carousel](skills/gemini-carousel/) | Slide-by-slide carousel generator with an approval gate. |
 | [quote-post](skills/quote-post/) | Claude writes the quote, Gemini recreates the image with the quote baked in. |
 | [analytics-dashboard](skills/analytics-dashboard/) | LinkedIn Analytics export to interactive React dashboard plus 5 data-backed recommendations. |
+| [post-publisher](skills/post-publisher/) | Publish or schedule the finished post to LinkedIn, Instagram, X, Threads, TikTok, YouTube and more in one call via Upload-Post. Previews the payload, waits for approval, reports per platform. |
 <!-- SKILLS:END -->
 
 ## Installation
@@ -129,6 +130,7 @@ Once installed, ask Claude to help with content tasks and it will pick the right
 "Turn this outlier Reel into a script" → reels-scripting
 "I need a thumbnail for 'How I fired my team'" → youtube-thumbnail
 "Write me a pinned comment" → pinned-comment
+"Publish this" or "schedule this for Monday" → post-publisher
 ```
 
 ## Skill Categories
@@ -162,6 +164,9 @@ Once installed, ask Claude to help with content tasks and it will pick the right
 ### Analytics
 - `analytics-dashboard` — LinkedIn export to dashboard + 5 recommendations
 
+### Publishing
+- `post-publisher` — publish or schedule the approved post to 9 platforms through Upload-Post, with a preview and approval gate
+
 ## Prerequisites
 
 A few skills need external services. Set these environment variables before use:
@@ -170,12 +175,15 @@ A few skills need external services. Set these environment variables before use:
 |---|---|
 | `APIFY_API_TOKEN` | post-scorer, reels-scripting |
 | `GOOGLE_AI_API_KEY` | reels-scripting (Gemini 2.5 Flash video analysis) |
+| `UPLOAD_POST_API_KEY` | post-publisher (free plan: 10 uploads a month, no card) |
+| `UPLOAD_POST_PROFILE` | post-publisher (optional, default profile name) |
 
 Set them with:
 
 ```bash
 export APIFY_API_TOKEN=your_token
 export GOOGLE_AI_API_KEY=your_key
+export UPLOAD_POST_API_KEY=your_key
 ```
 
 The image generation skills (`gemini-infographic`, `gemini-carousel`, `quote-post`, `youtube-thumbnail`, `profile-optimizer`) output ready-to-paste prompts. You run them in a separate Gemini chat with Create Image enabled. No API key needed.

--- a/skills/post-publisher/SKILL.md
+++ b/skills/post-publisher/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: post-publisher
+description: >
+  Publish or schedule a finished post to LinkedIn, Instagram, X, Threads, TikTok, YouTube, Facebook, Pinterest, Bluesky and more through the Upload-Post API, in one call. Use this skill whenever the user says "publish this", "post this", "schedule this post", "ship it to LinkedIn", "push this to my socials", "put this in the queue", or has a post, Reel script, carousel or thumbnail ready from another skill and wants it live. Always previews the exact payload and waits for approval before sending anything. Reports which platforms succeeded and which failed.
+---
+
+# Post Publisher
+
+## CRITICAL: Auto-start on load
+
+When this skill triggers, go straight to Step 1. Do not summarise. Do not explain how the API works. Start immediately.
+
+## What this skill does
+
+Every other skill in this repo ends with content in a code block or a saved file. This skill is the last step: it takes that content and publishes or schedules it on the user's connected accounts.
+
+It uses [Upload-Post](https://www.upload-post.com), one API for 21+ platforms. The user connects their accounts once in the Upload-Post dashboard. After that, one request fans out to every platform they pick and returns a per-platform result. No per-platform developer apps, no token refresh.
+
+The free plan covers most people using this repo: 10 uploads a month, 2 profiles, scheduling, analytics, no credit card. Paid plans raise the upload limit.
+
+## Step 1. Check setup
+
+Check for the environment variable `UPLOAD_POST_API_KEY`. Optionally `UPLOAD_POST_PROFILE` holds the default profile name.
+
+If the key is missing, say:
+
+> To publish I need an Upload-Post API key. Create a free account at https://www.upload-post.com (no card, 10 uploads a month), connect your accounts, create a profile, then generate a key under API Keys. Set it with:
+>
+> ```bash
+> export UPLOAD_POST_API_KEY=your_key
+> export UPLOAD_POST_PROFILE=your_profile_name
+> ```
+
+Then stop. Do not continue without a key.
+
+If the key exists, validate it:
+
+```bash
+curl -s "https://api.upload-post.com/api/uploadposts/me" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY"
+```
+
+A 401 means the key is wrong. Tell the user and stop. A 200 returns the account email and plan.
+
+Then list the profiles and what each one has connected:
+
+```bash
+curl -s "https://api.upload-post.com/api/uploadposts/users" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY"
+```
+
+Each profile has a `username` (the value you send as `user`) and a `social_accounts` map of connected platforms. Keep that list. It tells you which platforms the user can actually post to.
+
+## Step 2. Get the content
+
+Use the content in priority order:
+
+1. A post the user pasted in the same message.
+2. The most recent post saved by `post-writer` in the project (a markdown file saved on "ship it").
+3. A Reel script from `reels-scripting`, a carousel from `gemini-carousel`, or an image from `graphic-designer` that the user points to.
+
+If none of these exist, ask:
+
+> Paste the post, or give me the path to the file or media you want to publish.
+
+Wait for it.
+
+Detect the content type:
+
+- Text only: a post with no media.
+- Photos: one or more image paths (carousel if more than one).
+- Video: an .mp4 or .mov path.
+- Document: a PDF, for LinkedIn only.
+
+## Step 3. Gather targets
+
+Call AskUserQuestion with this JSON. Only list platforms that appeared as connected in Step 1.
+
+```json
+[
+  {
+    "question": "Where should this go?",
+    "header": "Platforms",
+    "multiSelect": true,
+    "options": [
+      {"label": "LinkedIn", "description": "Text, photos, video and PDF documents."},
+      {"label": "Instagram", "description": "Photos, carousels and Reels. No text-only posts."},
+      {"label": "X", "description": "Text, photos and video. 280 characters unless the account is Premium."},
+      {"label": "Threads", "description": "Text, photos, carousels and video."},
+      {"label": "TikTok", "description": "Video and photo carousels."},
+      {"label": "YouTube", "description": "Video only. A title is required."},
+      {"label": "Facebook", "description": "Text, photos and video to a Page."},
+      {"label": "Bluesky", "description": "Text and photos. 300 characters."},
+      {"label": "Pinterest", "description": "Photos and video pins. Needs a board."}
+    ]
+  },
+  {
+    "question": "When?",
+    "header": "Timing",
+    "multiSelect": false,
+    "options": [
+      {"label": "Publish now", "description": "Send immediately."},
+      {"label": "Schedule", "description": "Pick a date and time. I will ask for it next."},
+      {"label": "Add to queue", "description": "Upload-Post picks the next free slot from the profile's posting schedule."}
+    ]
+  }
+]
+```
+
+If "Schedule", ask for a date and time and the timezone. Convert to ISO 8601. Default timezone is the one in `about-me.md` if it exists, otherwise ask.
+
+If the user has more than one profile, ask which one. Otherwise use `UPLOAD_POST_PROFILE` or the single profile from Step 1.
+
+## Step 4. Adapt and preview
+
+Check the content against each chosen platform before building the request:
+
+- X and Bluesky have character limits. If the post is longer, offer a trimmed version in a code block and ask which to use. Never trim silently.
+- Instagram, TikTok and YouTube need media. If the content is text only, drop those platforms and say so.
+- YouTube and Reddit need a `title`. Reuse the hook line as the title if the user has not given one.
+- Keep line breaks. Upload-Post preserves them.
+- Never add hashtags, emojis or CTAs that were not in the approved content.
+
+Then show the exact request you are about to send, with the key masked:
+
+```bash
+curl -X POST "https://api.upload-post.com/api/upload_text" \
+  -H "Authorization: Apikey ****" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user": "mybrand",
+    "platform": ["linkedin", "x"],
+    "title": "First line of the post...",
+    "scheduled_date": "2026-09-08T09:00:00Z",
+    "timezone": "Europe/London"
+  }'
+```
+
+Ask:
+
+> Send it? Say "go" to publish, or tell me what to change.
+
+Wait for approval. Never send before the user says go.
+
+## Step 5. Send
+
+Pick the endpoint by content type.
+
+Text only:
+
+```bash
+curl -s -X POST "https://api.upload-post.com/api/upload_text" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"user": "PROFILE", "platform": ["linkedin", "x"], "title": "POST TEXT"}'
+```
+
+Photos or carousel:
+
+```bash
+curl -s -X POST "https://api.upload-post.com/api/upload_photos" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY" \
+  -F "user=PROFILE" \
+  -F "platform[]=instagram" \
+  -F "platform[]=linkedin" \
+  -F "photos[]=@slide-1.png" \
+  -F "photos[]=@slide-2.png" \
+  -F "title=POST TEXT"
+```
+
+Video:
+
+```bash
+curl -s -X POST "https://api.upload-post.com/api/upload" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY" \
+  -F "user=PROFILE" \
+  -F "platform[]=instagram" \
+  -F "platform[]=tiktok" \
+  -F "platform[]=youtube" \
+  -F "video=@reel.mp4" \
+  -F "title=POST TEXT" \
+  -F "async_upload=true"
+```
+
+Document (LinkedIn):
+
+```bash
+curl -s -X POST "https://api.upload-post.com/api/upload_document" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY" \
+  -F "user=PROFILE" \
+  -F "platform[]=linkedin" \
+  -F "document=@carousel.pdf" \
+  -F "title=POST TEXT"
+```
+
+Scheduling works the same on every endpoint. Add `scheduled_date` (ISO 8601) and `timezone` (IANA name). For the queue, add `add_to_queue=true` instead.
+
+Per-platform copy: if the user approved a different version for one platform, send it as `<platform>_title`, for example `x_title`.
+
+For video, always send `async_upload=true`. The response contains a `request_id`. Poll until it reaches a final state:
+
+```bash
+curl -s "https://api.upload-post.com/api/uploadposts/status?request_id=REQUEST_ID" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY"
+```
+
+Wait 15 seconds between polls. Stop after 10 minutes and tell the user to check the dashboard.
+
+## Step 6. Report
+
+A request can partially succeed. Read the per-platform results and report them in this format:
+
+```
+Published
+- LinkedIn: https://www.linkedin.com/feed/update/...
+- X: https://x.com/.../status/...
+
+Failed
+- Instagram: caption too long (2,200 character limit)
+
+Scheduled
+- Threads: 8 Sep 2026, 09:00 Europe/London (job abc123)
+```
+
+For a scheduled post, give the job id. The user can cancel it with:
+
+```bash
+curl -s -X DELETE "https://api.upload-post.com/api/uploadposts/schedule/JOB_ID" \
+  -H "Authorization: Apikey $UPLOAD_POST_API_KEY"
+```
+
+Then say:
+
+> Done. Say "write a pinned comment" to add a pinned comment, or "score my post" before the next one.
+
+## Rules
+
+- Never send a request before the user says "go" or equivalent. The preview in Step 4 is mandatory.
+- Never print the API key. Mask it in every preview and log line.
+- Never change the approved content beyond what the user agreed in Step 4.
+- Never add platforms the user did not pick, even if they are connected.
+- Always use the profile name as `user`, never a social handle.
+- Always send `async_upload=true` for video and poll for the result.
+- Always report partial failures platform by platform. Do not say "published" if one platform failed.
+- Always give the job id for scheduled posts so the user can cancel or edit them.
+- One post per run. For a batch, run the skill once per post so each one gets its own preview.
+- Full API reference: https://docs.upload-post.com. LLM-friendly version: https://docs.upload-post.com/llm.txt.


### PR DESCRIPTION
## What

Adds `post-publisher`, the missing last step of the system: every skill here ends with a post, a Reel script, a carousel or a thumbnail in a code block. This one takes that approved content and publishes or schedules it on the user's connected accounts in one call, through [Upload-Post](https://www.upload-post.com).

- Reads the post the user pasted, or the file `post-writer` saved on "ship it", or the media `reels-scripting` / `gemini-carousel` / `graphic-designer` produced.
- AskUserQuestion for platforms (only the ones actually connected) and timing (now, scheduled date, or the profile's posting queue).
- Adapts per platform (X and Bluesky limits, media-only platforms, YouTube title) and never trims silently.
- Shows the exact request with the key masked and waits for "go" before sending. Approval gate, same pattern as `gemini-carousel`.
- Async upload plus polling for video, and a per-platform report: published with links, failed with the reason, scheduled with the job id so it can be cancelled.

Follows CONTRIBUTING: British English, no em dashes, no semicolons, Rules section with always/never, `./validate-skills.sh` passes (18 skills, 0 warnings, 0 failures).

## Why Upload-Post

One API key covers 21+ platforms. Accounts are connected once by OAuth in the dashboard, so the skill never touches per-platform developer apps or token refresh. The free plan is enough for most people running this repo: 10 uploads a month, 2 profiles, scheduling and analytics included, no credit card. Paid plans only raise the upload limit.

Disclosure: I work on Upload-Post. Happy to change the skill name, trim scope, or move anything to `references/` if you prefer.

## README changes

- New row in the skills table and a "Publishing" category.
- `UPLOAD_POST_API_KEY` / `UPLOAD_POST_PROFILE` added to Prerequisites.
- One extra line in the usage examples ("Publish this" → post-publisher).

https://claude.ai/code/session_01Yc4Ciczkmw2BkcgtdYWEdS
